### PR TITLE
Release 1.3.5 changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,9 @@
 Revision history for DBIx-Squirrel
 
+### 1.3.5 2024-08-26 07:40
+
 1.3.4 2024-08-25 18:30
 
--   Typos fixed and POD updated.
 -   Some refactoring to improve robustness.
 
 1.3.3 2024-08-25 18:15

--- a/Changes
+++ b/Changes
@@ -1,6 +1,15 @@
 Revision history for DBIx-Squirrel
 
-### 1.3.5 2024-08-26 07:40
+1.3.5 2024-08-26 07:40
+
+-   Fixed a problem recently introduced into how transformation
+    pipelines and arguments are partitioned.
+-   Fixed the iterator execute method. It used the bleat about missing
+    bind- values, but that doesn’t make sense during construction when
+    there might legitimately be none. Now calling execute with none of
+    the expected bind-values just effectively resets the iterator.
+-   Fixed the results code that was breaking due to a missing
+    no strict qw/refs/.
 
 1.3.4 2024-08-25 18:30
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,13 @@
 ## Revision history for DBIx-Squirrel
 
 ### 1.3.5 2024-08-26 07:40
--   
+-   Fixed a problem recently introduced into how transformation pipelines and
+    arguments are partitioned.
+-   Fixed the iterator execute method. It used the bleat about missing bind-
+    values, but that doesn't make sense during construction when there might
+    legitimately be none. Now calling execute with none of the expected 
+    bind-values just effectively resets the iterator. 
+-   Fixed the results code that was breaking due to a missing `no strict qw/refs/`.
 
 ### 1.3.4 2024-08-25 18:30
 -   Some refactoring to improve robustness.

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,8 @@
 ## Revision history for DBIx-Squirrel
 
+### 1.3.5 2024-08-26 07:40
+-   
+
 ### 1.3.4 2024-08-25 18:30
 -   Some refactoring to improve robustness.
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = DBIx-Squirrel
-version = 1.3.4
+version = 1.3.5
 author  = Iain Campbell <cpanic@cpan.org>
 license = Perl_5
 copyright_holder = Iain Campbell

--- a/examples/transformations/02.pl
+++ b/examples/transformations/02.pl
@@ -1,5 +1,5 @@
 use DBIx::Squirrel database_entities => [qw/db get_artist_by_id/];
-use DBIx::Squirrel::Transform::IO         qw/stdout/;
+use DBIx::Squirrel::Transform::IO         qw/stderr/;
 use DBIx::Squirrel::Transform::JSON::Syck qw/as_json/;
 
 db do {
@@ -15,11 +15,11 @@ db do {
 };
 
 get_artist_by_id do {
-    db->results("SELECT * FROM artists WHERE ArtistId=? LIMIT 1" => as_json(), stdout("%s\n"))->reset({});
+    db->results("SELECT * FROM artists WHERE ArtistId=? LIMIT 1")->slice({});
 };
 
 foreach my $id (1 .. 9) {
-    get_artist_by_id($id)->single;
+    get_artist_by_id($id => as_json() => stderr("%s\n"))->single;
 }
 
 db->disconnect();

--- a/lib/DBIx/Squirrel.pm
+++ b/lib/DBIx/Squirrel.pm
@@ -45,7 +45,7 @@ BEGIN {
     *DBIx::Squirrel::NORMALIZE_SQL                = *DBIx::Squirrel::util::NORMALISE_SQL;
 
     unless (defined $DBIx::Squirrel::VERSION) {
-        my $v = "1.3.4";
+        my $v = "1.3.5";
         *DBIx::Squirrel::VERSION = \$v;
     }
 }

--- a/lib/DBIx/Squirrel/it.pm
+++ b/lib/DBIx/Squirrel/it.pm
@@ -291,7 +291,6 @@ sub execute {
           unless defined($attr->{bind_values}) && @{$attr->{bind_values}};
     }
     my $sth = $attr->{sth};
-    throw E_EXP_BIND_VALUES if $sth->{NUM_OF_PARAMS} && @{$attr->{bind_values}} < 1;
     $self->_private_state_reset;
     return do {$_ = $attr->{execute_returned} = $sth->execute(@{$attr->{bind_values}})};
 }

--- a/lib/DBIx/Squirrel/it.pm
+++ b/lib/DBIx/Squirrel/it.pm
@@ -21,7 +21,6 @@ use DBIx::Squirrel::util qw/part_args throw transform whine/;
 use constant E_BAD_STH         => 'Expected a statement handle object';
 use constant E_BAD_SLICE       => 'Slice must be a reference to an ARRAY or HASH';
 use constant E_BAD_BUFFER_SIZE => 'Maximum row count must be an integer greater than zero';
-use constant E_EXP_BIND_VALUES => 'Expected bind values but none have been presented';
 use constant W_MORE_ROWS       => 'Query would yield more than one result';
 use constant E_EXP_ARRAY_REF   => 'Expected an ARRAY-REF';
 

--- a/lib/DBIx/Squirrel/rs.pm
+++ b/lib/DBIx/Squirrel/rs.pm
@@ -2,7 +2,7 @@ use 5.010_001;
 use strict;
 use warnings;
 
-package    # hide from PAUSE
+package              # hide from PAUSE
   DBIx::Squirrel::rs;
 
 BEGIN {
@@ -78,6 +78,7 @@ sub row_class {
 }
 
 sub slice {
+    no strict 'refs';    ## no critic
     my($attr, $self) = shift->_private_state;
     my $slice = shift;
     my $old   = defined($attr->{slice}) ? $attr->{slice} : '';

--- a/lib/DBIx/Squirrel/util.pm
+++ b/lib/DBIx/Squirrel/util.pm
@@ -164,9 +164,9 @@ sub hash_sql_string {
 }
 
 sub part_args {
-    my @args = reverse(@_);
+    my @args = @_;
     my @coderefs;
-    unshift @coderefs, shift(@args) while UNIVERSAL::isa($args[0], 'CODE');
+    unshift @coderefs, pop(@args) while UNIVERSAL::isa($args[-1], 'CODE');
     return \@coderefs, @args;
 }
 


### PR DESCRIPTION
### Urgent fixes

-   Fixed a problem recently introduced into how transformation pipelines and
    arguments are partitioned.
-   Fixed the iterator execute method. It used the bleat about missing bind-
    values, but that doesn't make sense during construction when there might
    legitimately be none. Now calling execute with none of the expected 
    bind-values just effectively resets the iterator. 
-   Fixed the results code that was breaking due to a missing `no strict qw/refs/`.
